### PR TITLE
Better removal of tags in index.php when uninstall

### DIFF
--- a/functions/htmlcache.php
+++ b/functions/htmlcache.php
@@ -45,18 +45,15 @@ if (!function_exists('htmlcache_filename')) {
         }
         else {
             $beginning = '/*HTMLCache Begin*/';
-			$end = '/*HTMLCache End*/';
+	    $end = '/*HTMLCache End*/';
 
-			$beginningPos = strpos($contents, $beginning);
-			$endPos = strpos($contents, $end);
-
-			if ($beginningPos === false || $endPos === false) {
-				file_put_contents($file, $contents);
-			}
-
-			$textToDelete = substr($contents, $beginningPos, ($endPos + strlen($end)) - $beginningPos);
-
-			file_put_contents($file, str_replace($textToDelete, '', $contents));
+	    $beginningPos = strpos($contents, $beginning);
+	    $endPos = strpos($contents, $end);
+	    
+	    if ($beginningPos !== false && $endPos !== false) {
+	    	$textToDelete = substr($contents, $beginningPos, ($endPos + strlen($end)) - $beginningPos);
+	    	file_put_contents($file, str_replace($textToDelete, '', $contents));
+	    }
         }
     }
 

--- a/functions/htmlcache.php
+++ b/functions/htmlcache.php
@@ -44,7 +44,19 @@ if (!function_exists('htmlcache_filename')) {
             }
         }
         else {
-            file_put_contents($file, str_replace($replaceWith, '', $contents));
+            $beginning = '/*HTMLCache Begin*/';
+			$end = '/*HTMLCache End*/';
+
+			$beginningPos = strpos($contents, $beginning);
+			$endPos = strpos($contents, $end);
+
+			if ($beginningPos === false || $endPos === false) {
+				file_put_contents($file, $contents);
+			}
+
+			$textToDelete = substr($contents, $beginningPos, ($endPos + strlen($end)) - $beginningPos);
+
+			file_put_contents($file, str_replace($textToDelete, '', $contents));
         }
     }
 


### PR DESCRIPTION
This will move anything between the /_HTMLCache Begin_/, the /_HTMLCache End_/ and itself.
It is so that the old $replaceWith text is replaced.
