### PR TITLE
Explicitly turn output bufferring on with ob_start()

### DIFF
--- a/services/Htmlcache_HtmlcacheService.php
+++ b/services/Htmlcache_HtmlcacheService.php
@@ -28,6 +28,10 @@ class Htmlcache_HtmlcacheService extends BaseApplicationComponent
 
             return craft()->end();
         }
+        // Turn output buffering on
+        else {
+            ob_start();
+        }
     }
     
     public function canCreateCacheFile()
@@ -57,6 +61,7 @@ class Htmlcache_HtmlcacheService extends BaseApplicationComponent
     {
         if ($this->canCreateCacheFile()) {
             $content = ob_get_contents();
+            ob_end_flush();
             $file = $this->getCacheFileName();
             $fp = fopen($file, 'w+');
             if ($fp) {


### PR DESCRIPTION
This resolves an issue where the plugin would fail to save large pages to the cache, instead saving an empty cache file. It might also address a couple of open issues, such as #9 and #15.

In my case, I was having issues saving large JSON responses. A specific JSON API call would load fine the first time it was requested. However, the cache file would get written to disk with no content, and subsequent calls to that API endpoint would thus return nothing.

I did some research on the issue which suggested that calling `ob_start()` might resolve the issue, which it did in my case. This starts buffering the server response once called, which then gets sent to the user once `ob_get_contents()` is called. Hopefully it might help other developers who are having issues of this sort.

Love the plugin!
