### PR TITLE
Skip if it's an "action" request.

### DIFF
--- a/services/Htmlcache_HtmlcacheService.php
+++ b/services/Htmlcache_HtmlcacheService.php
@@ -48,6 +48,12 @@ class Htmlcache_HtmlcacheService extends BaseApplicationComponent
         if (craft()->request->isCpRequest()) {
             return false;
         }
+
+        // Skip if it's an action Request
+        if (craft()->request->isActionRequest()) {
+            return false;
+        }
+
         // Skip if it's a preview request
         if (craft()->request->isLivePreview()) {
             return false;


### PR DESCRIPTION
Action requests aren't front-end requests so they should be skipped too imho.

Thanks for your work on the plugin - defo takes some time to work around some of it's "beta" issues, but has great potential!
