### PR TITLE
Fixed installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ I've decided to keep this project Open Source/Beerware and to not publish it as 
 To install HTML Cache, follow these steps:
 
 1. Download & unzip the file and place the `htmlcache-master` directory into your `craft/plugins` directory
-2.  -OR- do a `git clone https://github.com/craftapi/htmlcache/htmlcache.git` directly into your `craft/plugins` folder.  You can then update it with `git pull`
+2.  -OR- do a `git clone https://github.com/craftapi/htmlcache.git` directly into your `craft/plugins` folder.  You can then update it with `git pull`
 3. Install plugin in the Craft Control Panel under Settings > Plugins
 4. The plugin folder should be named `htmlcache` for Craft to see it.  GitHub recently started appending `-master` (the branch name) to the name of the folder for zip file downloads.
 


### PR DESCRIPTION
The git clone command was not working, fixed with the correct clone address.