### PR TITLE
Retour redirects fix

### DIFF
--- a/services/Htmlcache_HtmlcacheService.php
+++ b/services/Htmlcache_HtmlcacheService.php
@@ -69,7 +69,7 @@ class Htmlcache_HtmlcacheService extends BaseApplicationComponent
     
     public function createCacheFile()
     {
-        if ($this->canCreateCacheFile()) {
+        if ($this->canCreateCacheFile() && http_response_code() == 200) {
             $content = ob_get_contents();
             ob_end_flush();
             $file = $this->getCacheFileName();


### PR DESCRIPTION
The Retour plugin checks if there is a 404 exception and then redirects the page if there is any. So we don't want to cache a 404 page because then the redirect stops working.