### PR TITLE
Add support for connected user

### DIFF
--- a/functions/htmlcache.php
+++ b/functions/htmlcache.php
@@ -24,10 +24,18 @@ if (!function_exists('htmlcache_filename')) {
         if (empty($host) && !empty($_SERVER['SERVER_NAME'])) {
             $host = $_SERVER['SERVER_NAME'];
         }
+        
+        try {
+            session_name('CraftSessionId');
+            @session_start();
+            $user = $_SESSION[reset(array_filter(array_keys($_SESSION), function ($key) { return substr($key, -6) === '__name'; }))];
+        } catch (\Exception $e) {
+            $user = '';
+        }
 
         $uri = $_SERVER['REQUEST_URI'];
 
-        $fileName = md5($protocol . $host . $uri) . '.html';
+        $fileName = md5($protocol . $user . $host . $uri) . '.html';
         if ($withDirectory) {
             $fileName = htmlcache_directory() . $fileName;
         }

--- a/functions/htmlcache.php
+++ b/functions/htmlcache.php
@@ -28,7 +28,7 @@ if (!function_exists('htmlcache_filename')) {
         try {
             session_name('CraftSessionId');
             @session_start();
-            $user = $_SESSION[reset(array_filter(array_keys($_SESSION), function ($key) { return substr($key, -6) === '__name'; }))];
+            $user = $_SESSION[@reset(array_filter(array_keys($_SESSION), function ($key) { return substr($key, -6) === '__name'; }))];
         } catch (\Exception $e) {
             $user = '';
         }


### PR DESCRIPTION
Caches should support multiple user. Otherwise cache for user A would show up for user B. For example user A and B would see "Greetings Michael".

The following pull request does not account for custom `phpSessionName`.