### PR TITLE
temporary solution for craftapi/htmlcache#49

### DIFF
--- a/HtmlcachePlugin.php
+++ b/HtmlcachePlugin.php
@@ -181,6 +181,8 @@ class HtmlcachePlugin extends BasePlugin
 
         if (!empty($values['htmlcacheSettingsForm'])) {
             // Write these settings to a .json file for offline reference
+            $values['enableCsrfProtection'] = craft()->config->get('enableCsrfProtection');
+            $values['csrfTokenName'] = craft()->config->get('csrfTokenName');
             $path = craft()->path->getStoragePath() . 'runtime' . DIRECTORY_SEPARATOR . 'htmlcache' . DIRECTORY_SEPARATOR;
             IOHelper::ensureFolderExists($path);
             $fp = fopen($path . 'settings.json', 'w+');


### PR DESCRIPTION
Hi There!

I see that there is work for a CSRF token solution in the `develop` branch. 

However, since that is currently unstable, I thought I would submit a work-around that I used in the interim. This just allows craft to be booted "on-demand" if a CSRF variable is detected.

There is still a performance hit vs fully by-passing craft (obviously.) However, I found that in my case there was still a marked performance improvement.